### PR TITLE
Mark fsevents as optional

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1322,7 +1322,8 @@
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
 			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"function-bind": {
 			"version": "1.1.2",


### PR DESCRIPTION
It is a transitive dependency introduced via `mocha` (not currently used but may be used later), so we can't prevent it from included in package-lock.json.

`chokidar` (directly depends on `fsevent`) optionally depends on it.

By removing package-lock.json and regenerating it with `npm i --lockfile-version 1`, `fsevents` was marked optional. To minimize diff of this commit, the file was reverted and then marked optional manually.